### PR TITLE
Fix decline from notif not ending in dashboard

### DIFF
--- a/app/src/main/java/com/sendbird/calls/quickstart/call/CallActivity.kt
+++ b/app/src/main/java/com/sendbird/calls/quickstart/call/CallActivity.kt
@@ -97,7 +97,7 @@ abstract class CallActivity : AppCompatActivity() {
         setCurrentState()
         if (mDoEnd) {
             Log.i(TAG, "[CallActivity] init() => (mDoEnd == true)")
-            end()
+            declineFromNotif()
             return
         }
         checkAuthentication()
@@ -134,6 +134,20 @@ abstract class CallActivity : AppCompatActivity() {
         mDoEnd = intent.getBooleanExtra(EXTRA_DO_END, false)
         if (mDoEnd) {
             Log.i(TAG, "[CallActivity] onNewIntent() => (mDoEnd == true)")
+            declineFromNotif()
+        }
+    }
+
+    private fun declineFromNotif() {
+        if (currentUser == null) {
+            autoAuthenticate(this) { userId ->
+                if (userId == null) {
+                    finishWithEnding("autoAuthenticate() failed.")
+                    return@autoAuthenticate
+                }
+                end()
+            }
+        } else {
             end()
         }
     }


### PR DESCRIPTION
When the app is in the background and the user declines a call it's not ending the call from SendBird's Dashboard

Reproducible steps:
- Open the sample app and then kill it (clear history)
- Make a call from the SendBird dashboard
- Press the decline button from the push notif

We expect the call to end in the dashboard side