### PR TITLE
Prevent clearing notif in not yet answered call

### DIFF
--- a/app/src/main/java/com/sendbird/calls/quickstart/call/CallService.kt
+++ b/app/src/main/java/com/sendbird/calls/quickstart/call/CallService.kt
@@ -113,6 +113,7 @@ class CallService : Service() {
         val builder = NotificationCompat.Builder(this, channelId).apply {
             setContentTitle(serviceData.remoteNicknameOrUserId)
             setContentText(content)
+            setOngoing(true)
             setSmallIcon(R.drawable.ic_sendbird)
             setLargeIcon(BitmapFactory.decodeResource(resources, R.drawable.icon_push_oreo))
             priority = NotificationCompat.PRIORITY_HIGH


### PR DESCRIPTION
Currently when a call is not answered yet, and the user clears the push notification
Then the call is still ongoing and a sound is playing, but the user has no way to accept/decline the call

This change is making the push notif sticky and prevents the issue above